### PR TITLE
[KM-150] 추가: 찜 삭제하기 구현, 미작성된 테스트 반영

### DIFF
--- a/src/main/java/com/devcourse/kurlymurly/global/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/kurlymurly/global/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     // 400
 
     // 404
+    NEVER_FAVORITE(HttpStatus.NOT_FOUND, "찜 이력이 존재하지 않습니다."),
 
     // 409
 
@@ -25,7 +26,7 @@ public enum ErrorCode {
         return httpStatus;
     }
 
-    String getMessage() {
+    public String getMessage() {
         return message;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/product/domain/favorite/Favorite.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/product/domain/favorite/Favorite.java
@@ -30,4 +30,16 @@ public class Favorite extends BaseEntity {
         this.productId = productId;
         this.status = Status.NORMAL;
     }
+
+    public void activate() {
+        this.status = Status.NORMAL;
+    }
+
+    public void softDelete() {
+        this.status = Status.DELETED;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/product/domain/favorite/FavoriteRepository.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/product/domain/favorite/FavoriteRepository.java
@@ -2,5 +2,8 @@ package com.devcourse.kurlymurly.module.product.domain.favorite;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    Optional<Favorite> findByUserIdAndProductId(Long userId, Long productId);
 }

--- a/src/main/java/com/devcourse/kurlymurly/web/product/ProductController.java
+++ b/src/main/java/com/devcourse/kurlymurly/web/product/ProductController.java
@@ -74,4 +74,14 @@ public class ProductController {
         productFacade.delete(id);
         return KurlyResponse.noData();
     }
+
+    @DeleteMapping("/{id}/favorite")
+    @ResponseStatus(NO_CONTENT)
+    public KurlyResponse<Void> cancelProduct(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long id
+    ) {
+        productFacade.cancelFavorite(user.getId(), id);
+        return KurlyResponse.noData();
+    }
 }

--- a/src/test/java/com/devcourse/kurlymurly/module/product/FavoriteFixture.java
+++ b/src/test/java/com/devcourse/kurlymurly/module/product/FavoriteFixture.java
@@ -1,0 +1,28 @@
+package com.devcourse.kurlymurly.module.product;
+
+import com.devcourse.kurlymurly.module.product.domain.favorite.Favorite;
+
+public enum FavoriteFixture {
+    FAVORITE_FIXTURE(1L, 1L),
+    ;
+
+    private final Long userId;
+    private final Long productId;
+
+    FavoriteFixture(Long userId, Long productId) {
+        this.userId = userId;
+        this.productId = productId;
+    }
+
+    public Favorite toEntity() {
+        return new Favorite(this.userId, this.productId);
+    }
+
+    public Long userId() {
+        return userId;
+    }
+
+    public Long productId() {
+        return productId;
+    }
+}

--- a/src/test/java/com/devcourse/kurlymurly/module/product/domain/favorite/FavoriteRepositoryTest.java
+++ b/src/test/java/com/devcourse/kurlymurly/module/product/domain/favorite/FavoriteRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.devcourse.kurlymurly.module.product.domain.favorite;
+
+import com.devcourse.kurlymurly.module.product.FavoriteFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class FavoriteRepositoryTest {
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+
+    private final FavoriteFixture fixture = FavoriteFixture.FAVORITE_FIXTURE;
+
+    @Test
+    @DisplayName("유저 ID와 상품 ID로 저장된 favorite을 찾을 수 있다.")
+    void findByUserIdAndProductId() {
+        // given
+        Favorite favorite = fixture.toEntity();
+        favoriteRepository.save(favorite);
+
+        // when
+        Optional<Favorite> optionalFavorite = favoriteRepository.findByUserIdAndProductId(fixture.userId(), fixture.productId());
+
+        // then
+        assertThat(optionalFavorite).isNotEmpty();
+        assertThat(optionalFavorite.get()).usingRecursiveComparison().isEqualTo(favorite);
+    }
+}


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠?
-->
# 🔍 어떤 PR인가요?
- 찜 삭제하기 구현입니다.
- 그리고 찜하기에서 미작성된 테스트를 반영했습니다😋

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요.
-->
# 😋 To Reviewer
- 재사용에 목적을 두고 찜을 구현했는데 이 부분에 대해서 한번 봐주셨음 좋을 것 같습니다!

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail : 중복된 이메일로 저장 실패 테스트 작성)
-->
# ✅ Test
- [x] favoriteProduct_Success_WithSavedFavorite : 이미 생성된 찜이 있다면 해당 찜을 활성화 시킨다.
- [x] favoriteProduct_Success_WithNewFavorite : 저장된 찜이 없다면 새로운 찜을 만들어낸다.
- [x] cancelFavorite_Success : 삭제 요청이 들어오면 찜의 상태가 DELETED로 변경된다.
- [x] cancelFavorite_Fail_ByNotExistFavorite : 존재하지 않는 찜을 취소하려고 하면 예외가 발생한다.
