### PR TITLE
[KM-253] 추가:배송 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
@@ -23,15 +23,15 @@ public class Address {
     }
 
     public boolean isExpress() {
-        return isExpress;
+        return this.isExpress;
     }
 
     public String getRoadAddress() {
-        return roadAddress;
+        return this.roadAddress;
     }
 
     public String getDescription() {
-        return description;
+        return this.description;
     }
 
     public String getDescribedAddress() {

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
@@ -27,6 +27,6 @@ public class Address {
     }
 
     public String getDescribedAddress() {
-        return this.roadAddress + " " + this.description;
+        return this.description == null ? this.roadAddress : this.roadAddress + " " + this.description;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
@@ -35,6 +35,6 @@ public class Address {
     }
 
     public String getDescribedAddress() {
-        return this.roadAddress+" "+this.description;
+        return this.roadAddress + " " + this.description;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
@@ -5,21 +5,36 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class Address {
+    @Column(nullable = false, length = 100)
+    private String roadAddress;
+
+    @Column(length = 100)
+    private String description;
+
+    @Column(nullable = false)
+    private boolean isExpress;
+
+    protected Address() {
+    }
+
     public Address(String address, boolean matches) {
         this.roadAddress = address;
         this.isExpress = matches;
     }
 
-    protected Address() {
-    }
-
-    @Column(nullable = false, length = 100)
-    private String roadAddress;
-
-    @Column(nullable = false)
-    private boolean isExpress;
-
     public boolean isExpress() {
         return isExpress;
+    }
+
+    public String getRoadAddress() {
+        return roadAddress;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDescribedAddress() {
+        return this.roadAddress+" "+this.description;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Address.java
@@ -26,14 +26,6 @@ public class Address {
         return this.isExpress;
     }
 
-    public String getRoadAddress() {
-        return this.roadAddress;
-    }
-
-    public String getDescription() {
-        return this.description;
-    }
-
     public String getDescribedAddress() {
         return this.roadAddress + " " + this.description;
     }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
@@ -5,19 +5,19 @@ import jakarta.persistence.Embeddable;
 
 @Embeddable
 public class Info {
-    @Column(length = 30)
+    @Column(nullable = false, length = 30)
     private String receiver;
 
-    @Column(length = 15)
+    @Column(nullable = false, length = 15)
     private String contact;
 
-    @Column(length = 15)
+    @Column(nullable = false, length = 15)
     private String receiveArea;
 
-    @Column(length = 10)
+    @Column(nullable = false, length = 10)
     private String entrancePassword;
 
-    @Column(length = 10)
+    @Column(nullable = false, length = 10)
     private String messageAlertTime;
 
     public Info() {

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
@@ -19,4 +19,20 @@ public class Info {
 
     @Column(length = 10)
     private String messageAlertTime;
+
+    public Info() {
+        this.receiver = "none";
+        this.contact = "none";
+        this.receiveArea = "none";
+        this.entrancePassword = "none";
+        this.messageAlertTime = "none";
+    }
+
+    public String getReceiver() {
+        return receiver;
+    }
+
+    public String getContact() {
+        return contact;
+    }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Info.java
@@ -29,10 +29,10 @@ public class Info {
     }
 
     public String getReceiver() {
-        return receiver;
+        return this.receiver;
     }
 
     public String getContact() {
-        return contact;
+        return this.contact;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
@@ -44,14 +44,14 @@ public class Shipping extends BaseEntity {
     }
 
     public Address getAddress() {
-        return address;
+        return this.address;
     }
 
     public Info getInfo() {
-        return info;
+        return this.info;
     }
 
     public boolean isDefault() {
-        return isDefault;
+        return this.isDefault;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
@@ -13,23 +13,6 @@ import java.util.regex.Pattern;
 public class Shipping extends BaseEntity {
     private static final Pattern EXPRESS_REGEX = Pattern.compile("^[서울|경기|인천|충청|대구|부산|울산|양산|창원|김해].*");
 
-    public Shipping(Long userId, String roadAddress, boolean isDefault) {
-        Address address = checkExpress(roadAddress);
-
-        this.userId = userId;
-        this.address = address;
-        this.isDefault = isDefault;
-    }
-
-    private static Address checkExpress(String roadAddress) {
-        boolean matches = EXPRESS_REGEX.matcher(roadAddress).matches();
-        Address address = new Address(roadAddress, matches);
-        return address;
-    }
-
-    protected Shipping() {
-    }
-
     @Column(nullable = false)
     private Long userId;
 
@@ -42,7 +25,33 @@ public class Shipping extends BaseEntity {
     @Column(nullable = false)
     private boolean isDefault;
 
+    protected Shipping() {
+    }
+
+    public Shipping(Long userId, String roadAddress, boolean isDefault) {
+        Address address = checkExpress(roadAddress);
+
+        this.userId = userId;
+        this.address = address;
+        this.isDefault = isDefault;
+        this.info = new Info();
+    }
+
+    private Address checkExpress(String roadAddress) {
+        boolean matches = EXPRESS_REGEX.matcher(roadAddress).matches();
+        Address address = new Address(roadAddress, matches);
+        return address;
+    }
+
     public Address getAddress() {
         return address;
+    }
+
+    public Info getInfo() {
+        return info;
+    }
+
+    public boolean isDefault() {
+        return isDefault;
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
@@ -1,6 +1,7 @@
 package com.devcourse.kurlymurly.module.user.domain.shipping;
 
 import com.devcourse.kurlymurly.module.BaseEntity;
+import com.devcourse.kurlymurly.web.dto.user.shipping.GetAddress;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -46,11 +47,13 @@ public class Shipping extends BaseEntity {
         return this.address;
     }
 
-    public Info getInfo() {
-        return this.info;
-    }
-
-    public boolean isDefault() {
-        return this.isDefault;
+    public GetAddress.Response getAddressDto() {
+        return new GetAddress.Response(
+                this.isDefault,
+                this.address.isExpress(),
+                this.address.getDescribedAddress(),
+                this.info.getReceiver(),
+                this.info.getContact()
+        );
     }
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/Shipping.java
@@ -39,8 +39,7 @@ public class Shipping extends BaseEntity {
 
     private Address checkExpress(String roadAddress) {
         boolean matches = EXPRESS_REGEX.matcher(roadAddress).matches();
-        Address address = new Address(roadAddress, matches);
-        return address;
+        return new Address(roadAddress, matches);
     }
 
     public Address getAddress() {

--- a/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/ShippingRepository.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/domain/shipping/ShippingRepository.java
@@ -2,5 +2,8 @@ package com.devcourse.kurlymurly.module.user.domain.shipping;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ShippingRepository extends JpaRepository<Shipping, Long> {
+    List<Shipping> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
@@ -19,6 +19,7 @@ import com.devcourse.kurlymurly.web.dto.product.review.ReviewResponse;
 import com.devcourse.kurlymurly.web.dto.user.JoinUser;
 import com.devcourse.kurlymurly.web.dto.user.LoginUser;
 import com.devcourse.kurlymurly.web.dto.user.UpdateUser;
+import com.devcourse.kurlymurly.web.dto.user.shipping.GetAddress;
 import com.devcourse.kurlymurly.web.exception.ExistUserInfoException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -60,7 +61,7 @@ public class UserService {
             ShippingRepository shippingRepository,
             PaymentRepository paymentRepository,
             JwtTokenProvider tokenProvider,
-            OrderService orderService
+            OrderService orderService,
             AuthenticationManagerBuilder authenticationManagerBuilder
     ) {
         this.userRepository = userRepository;
@@ -70,7 +71,7 @@ public class UserService {
         this.shippingRepository = shippingRepository;
         this.paymentRepository = paymentRepository;
         this.tokenProvider = tokenProvider;
-        this.orderService = orderService; 
+        this.orderService = orderService;
         this.authenticationManagerBuilder = authenticationManagerBuilder;
     }
 
@@ -132,6 +133,17 @@ public class UserService {
         Shipping shipping = new Shipping(userId, address, isDefault);
 
         shippingRepository.save(shipping);
+    }
+
+    public List<GetAddress.Response> getAddress(Long userId) {
+        List<Shipping> shippingList = shippingRepository.findAllById(Collections.singleton(userId));
+        return shippingList.stream().map(this::convertToAddressDto).toList();
+    }
+
+    private GetAddress.Response convertToAddressDto(Shipping shipping) {
+        return new GetAddress.Response(shipping.isDefault(), shipping.getAddress().isExpress()
+                , shipping.getAddress().getDescribedAddress(), shipping.getInfo().getReceiver()
+                , shipping.getInfo().getContact());
     }
 
     @Transactional

--- a/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
@@ -136,8 +136,9 @@ public class UserService {
     }
 
     public List<GetAddress.Response> getAddress(Long userId) {
-        List<Shipping> shippingList = shippingRepository.findAllByUserId(userId);
-        return shippingList.stream().map(this::convertToAddressDto).toList();
+        return shippingRepository.findAllByUserId(userId).stream()
+                .map(this::convertToAddressDto)
+                .toList();
     }
 
     private GetAddress.Response convertToAddressDto(Shipping shipping) {

--- a/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
@@ -136,7 +136,7 @@ public class UserService {
     }
 
     public List<GetAddress.Response> getAddress(Long userId) {
-        List<Shipping> shippingList = shippingRepository.findAllById(Collections.singleton(userId));
+        List<Shipping> shippingList = shippingRepository.findAllByUserId(userId);
         return shippingList.stream().map(this::convertToAddressDto).toList();
     }
 

--- a/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
@@ -141,9 +141,7 @@ public class UserService {
     }
 
     private GetAddress.Response to(Shipping shipping) {
-        return new GetAddress.Response(shipping.isDefault(), shipping.getAddress().isExpress()
-                , shipping.getAddress().getDescribedAddress(), shipping.getInfo().getReceiver()
-                , shipping.getInfo().getContact());
+        return shipping.getAddressDto();
     }
 
     @Transactional

--- a/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
+++ b/src/main/java/com/devcourse/kurlymurly/module/user/service/UserService.java
@@ -17,7 +17,6 @@ import com.devcourse.kurlymurly.module.user.domain.shipping.ShippingRepository;
 import com.devcourse.kurlymurly.web.dto.payment.RegisterPayment;
 import com.devcourse.kurlymurly.web.dto.product.review.ReviewResponse;
 import com.devcourse.kurlymurly.web.dto.user.JoinUser;
-import com.devcourse.kurlymurly.web.dto.user.LoginUser;
 import com.devcourse.kurlymurly.web.dto.user.UpdateUser;
 import com.devcourse.kurlymurly.web.dto.user.shipping.GetAddress;
 import com.devcourse.kurlymurly.web.exception.ExistUserInfoException;
@@ -90,7 +89,7 @@ public class UserService {
 
     @Transactional
     public void join(JoinUser.Request request) {
-        User newUser = convertToUser(request);
+        User newUser = to(request);
 
         checkPassword(request.password(), request.checkPassword());
 
@@ -137,11 +136,11 @@ public class UserService {
 
     public List<GetAddress.Response> getAddress(Long userId) {
         return shippingRepository.findAllByUserId(userId).stream()
-                .map(this::convertToAddressDto)
+                .map(this::to)
                 .toList();
     }
 
-    private GetAddress.Response convertToAddressDto(Shipping shipping) {
+    private GetAddress.Response to(Shipping shipping) {
         return new GetAddress.Response(shipping.isDefault(), shipping.getAddress().isExpress()
                 , shipping.getAddress().getDescribedAddress(), shipping.getInfo().getReceiver()
                 , shipping.getInfo().getContact());
@@ -224,7 +223,7 @@ public class UserService {
         return userRepository.existsByEmail(email);
     }
 
-    private User convertToUser(JoinUser.Request request) {
+    private User to(JoinUser.Request request) {
         UserInfo userInfo = new UserInfo(request.birth(), request.recommender(), request.sex());
 
         return new User(request.name(), request.loginId(), passwordEncoder.encode(request.password()), request.email(), userInfo, request.phoneNumber());

--- a/src/main/java/com/devcourse/kurlymurly/web/dto/user/shipping/GetAddress.java
+++ b/src/main/java/com/devcourse/kurlymurly/web/dto/user/shipping/GetAddress.java
@@ -7,7 +7,7 @@ public sealed interface GetAddress permits GetAddress.Response {
             @Schema(name = "기본 배송지 여부")
             boolean isDefault,
 
-            @Schema(name = "기본 배송지 여부")
+            @Schema(name = "샛별 배송지 여부")
             boolean isExpress,
 
             @Schema(name = "도로명 주소 + 상세 주소")

--- a/src/main/java/com/devcourse/kurlymurly/web/dto/user/shipping/GetAddress.java
+++ b/src/main/java/com/devcourse/kurlymurly/web/dto/user/shipping/GetAddress.java
@@ -1,0 +1,23 @@
+package com.devcourse.kurlymurly.web.dto.user.shipping;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public sealed interface GetAddress permits GetAddress.Response {
+    record Response(
+            @Schema(name = "기본 배송지 여부")
+            boolean isDefault,
+
+            @Schema(name = "기본 배송지 여부")
+            boolean isExpress,
+
+            @Schema(name = "도로명 주소 + 상세 주소")
+            String address,
+
+            @Schema(name = "수취인")
+            String receiver,
+
+            @Schema(name = "연락처")
+            String phoneNumber
+    ) implements GetAddress {
+    }
+}

--- a/src/main/java/com/devcourse/kurlymurly/web/user/UserController.java
+++ b/src/main/java/com/devcourse/kurlymurly/web/user/UserController.java
@@ -17,6 +17,7 @@ import com.devcourse.kurlymurly.web.dto.user.JoinUser;
 import com.devcourse.kurlymurly.web.dto.user.LoginUser;
 import com.devcourse.kurlymurly.web.dto.user.UpdateUser;
 import com.devcourse.kurlymurly.web.dto.user.shipping.AddAddress;
+import com.devcourse.kurlymurly.web.dto.user.shipping.GetAddress;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -98,6 +99,13 @@ public class UserController {
         return KurlyResponse.noData();
     }
 
+    @GetMapping("/addresses")
+    @ResponseStatus(OK)
+    public KurlyResponse<List<GetAddress.Response>> getAddress(@AuthenticationPrincipal User user) {
+        List<GetAddress.Response> addressList = userService.getAddress(user.getId());
+        return KurlyResponse.ok(addressList);
+    }
+
     @PostMapping("/register-credit")
     @ResponseStatus(NO_CONTENT)
     public KurlyResponse<Void> addCredit(@AuthenticationPrincipal User user, @RequestBody RegisterPayment.creditRequest request) {
@@ -122,7 +130,7 @@ public class UserController {
     @PutMapping("/delete-credit/{paymentId}")
     @ResponseStatus(OK)
     public KurlyResponse<Void> deletePayment(@AuthenticationPrincipal User user, @PathVariable Long paymentId) {
-        userService.deletePayment(user.getId(),paymentId);
+        userService.deletePayment(user.getId(), paymentId);
 
         return KurlyResponse.noData();
     }

--- a/src/test/java/com/devcourse/kurlymurly/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/devcourse/kurlymurly/module/user/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import com.devcourse.kurlymurly.web.dto.payment.RegisterPayment;
 import com.devcourse.kurlymurly.web.dto.product.RemoveCart;
 import com.devcourse.kurlymurly.web.dto.user.JoinUser;
 import com.devcourse.kurlymurly.web.dto.user.UpdateUser;
+import com.devcourse.kurlymurly.web.dto.user.shipping.GetAddress;
 import com.devcourse.kurlymurly.web.exception.ExistUserInfoException;
 
 import org.junit.jupiter.api.Assertions;
@@ -144,6 +145,22 @@ class UserServiceTest {
 
         // Then
         assertThat(shipping.getAddress().isExpress()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원에게 등록된 배송주소들을 가져온다.")
+    void get_addresses() {
+        // Given
+        Shipping shipping1 = new Shipping(1L, "컬리단길", true);
+        Shipping shipping2 = new Shipping(1L, "컬리단길", true);
+
+        doReturn(List.of(shipping1, shipping2)).when(shippingRepository).findAllById(any());
+
+        // When
+        List<GetAddress.Response> addressList = userService.getAddress(1L);
+
+        // Then
+        assertThat(addressList.size()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/devcourse/kurlymurly/module/user/service/UserServiceTest.java
+++ b/src/test/java/com/devcourse/kurlymurly/module/user/service/UserServiceTest.java
@@ -154,7 +154,7 @@ class UserServiceTest {
         Shipping shipping1 = new Shipping(1L, "컬리단길", true);
         Shipping shipping2 = new Shipping(1L, "컬리단길", true);
 
-        doReturn(List.of(shipping1, shipping2)).when(shippingRepository).findAllById(any());
+        doReturn(List.of(shipping1, shipping2)).when(shippingRepository).findAllByUserId(any());
 
         // When
         List<GetAddress.Response> addressList = userService.getAddress(1L);


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 유저에게 등록된 배송지를 등록하는 기능을 추가했습니다!
- 
![image](https://github.com/prgrms-be-devcourse/BE-04-KurlyMurly/assets/102570281/433914b7-d1ac-457e-ba4c-86995c084ee3)


<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요.
-->
# 😋 To Reviewer
- 주소 조회 시에 도로명 주소 + 상세 주소 형식으로 나오도록 하였습니다 !
- 수취인 , 연락처 등이 필수가 아니기에 빈 값 조회 시를 대비해서 "none" 을 넣어주었습니다 

# ✅ Test
- [ ] get_addresses : 회원에게 등록된 배송주소들을 가져온다.
