### PR TITLE
[KM-294] 추가: 1:1문의 응답 DTO 추가

### DIFF
--- a/module-api/src/main/java/com/devcourse/kurlymurly/order/OrderSupportController.java
+++ b/module-api/src/main/java/com/devcourse/kurlymurly/order/OrderSupportController.java
@@ -1,8 +1,8 @@
 package com.devcourse.kurlymurly.order;
 
-import com.devcourse.kurlymurly.module.order.domain.support.OrderSupport;
 import com.devcourse.kurlymurly.module.order.service.OrderSupportService;
 import com.devcourse.kurlymurly.module.user.domain.User;
+import com.devcourse.kurlymurly.web.common.KurlyResponse;
 import com.devcourse.kurlymurly.web.dto.order.support.CreateOrderSupport;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,22 +36,17 @@ public class OrderSupportController {
     @Tag(name = "orderSupport")
     @Operation(description = "[토큰 필요] 1:1 문의를 생성한다.", responses = {
             @ApiResponse(responseCode = "200", description = "성공적으로 1:1 문의를 생성한 경우"),
+            @ApiResponse(responseCode = "400", description = "1:1 문의를 작성하기 위한 사용자 응답이 적절하지 않은 경우"),
             @ApiResponse(responseCode = "401", description = "토큰을 넣지 않은 경우")
     })
     @PostMapping
     @ResponseStatus(OK)
-    public OrderSupport takeOrderSupport(
+    public KurlyResponse<CreateOrderSupport.Response> takeOrderSupport(
             @AuthenticationPrincipal User user,
             @RequestBody @Valid CreateOrderSupport.Request request
     ) {
-        return orderSupportService.takeOrderSupport(
-                user.getId(),
-                request.orderId(),
-                request.orderNumber(),
-                request.type(),
-                request.title(),
-                request.content()
-        );
+        CreateOrderSupport.Response OrderSupportResponse = orderSupportService.takeOrderSupport(user.getId(), request);
+        return KurlyResponse.ok(OrderSupportResponse);
     }
 
     @Tag(name = "orderSupport")
@@ -61,8 +56,9 @@ public class OrderSupportController {
     })
     @GetMapping
     @ResponseStatus(OK)
-    public List<OrderSupport> findAllByUserId(@AuthenticationPrincipal User user) {
-        return orderSupportService.findAllByUserId(user.getId());
+    public KurlyResponse<List<CreateOrderSupport.Response>> findAllByUserId(@AuthenticationPrincipal User user) {
+        List<CreateOrderSupport.Response> orderSupportResponses = orderSupportService.findAllByUserId(user.getId());
+        return KurlyResponse.ok(orderSupportResponses);
     }
 
     @Tag(name = "orderSupport")
@@ -73,11 +69,12 @@ public class OrderSupportController {
     })
     @PatchMapping("/{id}")
     @ResponseStatus(OK)
-    public OrderSupport updateOrderSupport(
+    public KurlyResponse<Void> updateOrderSupport(
             @PathVariable Long id,
             @RequestBody @Valid CreateOrderSupport.UpdateRequest request
     ) {
-        return orderSupportService.updateOrderSupport(id, request.title(), request.content());
+        orderSupportService.updateOrderSupport(id, request.title(), request.content());
+        return KurlyResponse.noData();
     }
 
     @Tag(name = "orderSupport")
@@ -88,7 +85,8 @@ public class OrderSupportController {
     })
     @DeleteMapping("/{id}")
     @ResponseStatus(OK)
-    public void deleteOrderSupport(@PathVariable Long id) {
+    public KurlyResponse<Void> deleteOrderSupport(@PathVariable Long id) {
         orderSupportService.deleteOrderSupport(id);
+        return KurlyResponse.noData();
     }
 }

--- a/module-core/src/main/java/com/devcourse/kurlymurly/module/BaseEntity.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/module/BaseEntity.java
@@ -43,4 +43,8 @@ public abstract class BaseEntity {
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
     }
+
+    public void changeUpdateDate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/module-core/src/main/java/com/devcourse/kurlymurly/module/BaseEntity.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/module/BaseEntity.java
@@ -44,7 +44,7 @@ public abstract class BaseEntity {
         return updatedAt;
     }
 
-    public void changeUpdateDate() {
+    public void changeUpdatedDate() {
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/module-core/src/main/java/com/devcourse/kurlymurly/module/order/domain/support/OrderSupport.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/module/order/domain/support/OrderSupport.java
@@ -65,6 +65,22 @@ public class OrderSupport extends BaseEntity {
         this.status = Status.PREPARE;
     }
 
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
     public void toPreparedSupport() {
         this.status = Status.PREPARE;
     }
@@ -81,17 +97,6 @@ public class OrderSupport extends BaseEntity {
     public void updateOrderSupport(String title, String content) {
         this.title = title;
         this.content = content;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getContent() {
-        return content;
+        changeUpdateDate();
     }
 }

--- a/module-core/src/main/java/com/devcourse/kurlymurly/module/order/domain/support/OrderSupport.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/module/order/domain/support/OrderSupport.java
@@ -66,19 +66,19 @@ public class OrderSupport extends BaseEntity {
     }
 
     public Status getStatus() {
-        return status;
+        return this.status;
     }
 
     public String getTitle() {
-        return title;
+        return this.title;
     }
 
     public String getContent() {
-        return content;
+        return this.content;
     }
 
     public Type getType() {
-        return type;
+        return this.type;
     }
 
     public void toPreparedSupport() {
@@ -97,6 +97,6 @@ public class OrderSupport extends BaseEntity {
     public void updateOrderSupport(String title, String content) {
         this.title = title;
         this.content = content;
-        changeUpdateDate();
+        changeUpdatedDate();
     }
 }

--- a/module-core/src/main/java/com/devcourse/kurlymurly/web/dto/order/support/CreateOrderSupport.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/web/dto/order/support/CreateOrderSupport.java
@@ -5,10 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
+
 import static com.devcourse.kurlymurly.web.dto.order.support.CreateOrderSupport.Request;
+import static com.devcourse.kurlymurly.web.dto.order.support.CreateOrderSupport.Response;
 import static com.devcourse.kurlymurly.web.dto.order.support.CreateOrderSupport.UpdateRequest;
 
-public sealed interface CreateOrderSupport permits Request, UpdateRequest {
+public sealed interface CreateOrderSupport permits Request, Response, UpdateRequest {
     record Request(
             @NotNull(message = "빈 값이 들어올 수 없습니다.")
             @Schema(name = "주문 아이디")
@@ -19,7 +22,7 @@ public sealed interface CreateOrderSupport permits Request, UpdateRequest {
             String orderNumber,
 
             @NotNull(message = "빈 값이 들어올 수 없습니다.")
-            @Schema(name = "1대1 문의 타입", allowableValues = { "DELIVERY",  "MISSING",  "PRODUCT",  "ORDER",  "EVENT",  "ETC" })
+            @Schema(name = "1대1 문의 타입", allowableValues = {"DELIVERY", "MISSING", "PRODUCT", "ORDER", "EVENT", "ETC"})
             OrderSupport.Type type,
 
             @NotBlank(message = "빈 값이 들어올 수 없습니다.")
@@ -29,6 +32,15 @@ public sealed interface CreateOrderSupport permits Request, UpdateRequest {
             @NotBlank(message = "빈 값이 들어올 수 없습니다.")
             @Schema(name = "1대1 문의 내용")
             String content
+    ) implements CreateOrderSupport {
+    }
+
+    record Response(
+            OrderSupport.Type type,
+            String title,
+            String content,
+            OrderSupport.Status status,
+            LocalDateTime createdAt
     ) implements CreateOrderSupport {
     }
 

--- a/module-core/src/test/java/com/devcourse/kurlymurly/module/orderSupport/service/OrderSupportServiceTest.java
+++ b/module-core/src/test/java/com/devcourse/kurlymurly/module/orderSupport/service/OrderSupportServiceTest.java
@@ -38,17 +38,9 @@ class OrderSupportServiceTest {
                 request.type(), request.title(), request.content());
     }
 
-    private OrderSupport takeOrderSupportService(OrderSupport orderSupport) {
+    private void takeOrderSupportService(OrderSupport orderSupport) {
         given(orderSupportRepository.save(any())).willReturn(orderSupport);
-
-        return orderSupportService.takeOrderSupport(
-                userId,
-                request.orderId(),
-                request.orderNumber(),
-                request.type(),
-                request.title(),
-                request.content()
-        );
+        orderSupportService.takeOrderSupport(userId, request);
     }
 
     @BeforeEach
@@ -72,10 +64,7 @@ class OrderSupportServiceTest {
         given(orderSupportRepository.save(any())).willReturn(orderSupport);
 
         // when
-        OrderSupport orderSupportService = takeOrderSupportService(orderSupport);
-
-        // then
-        assertThat(orderSupport).usingRecursiveComparison().isEqualTo(orderSupportService);
+        takeOrderSupportService(orderSupport);
     }
 
     @Test
@@ -107,10 +96,13 @@ class OrderSupportServiceTest {
 
         // when
         takeOrderSupportService(orderSupport);
-        List<OrderSupport> entity = orderSupportService.findAllByUserId(userId);
+        List<CreateOrderSupport.Response> entity = orderSupportService.findAllByUserId(userId);
 
         // then
-        assertThat(orderSupport).usingRecursiveComparison().isEqualTo(entity.get(0));
+        CreateOrderSupport.Response response = new CreateOrderSupport.Response(orderSupport.getType(), orderSupport.getTitle(), orderSupport.getContent(),
+                orderSupport.getStatus(), orderSupport.getCreateAt());
+
+        assertThat(response).usingRecursiveComparison().isEqualTo(entity.get(0));
     }
 
     @Test
@@ -123,11 +115,11 @@ class OrderSupportServiceTest {
         given(orderSupportRepository.findById(any())).willReturn(Optional.of(orderSupport));
 
         // when
-        OrderSupport entity = takeOrderSupportService(orderSupport);
-        orderSupportService.updateSupportToPrepare(entity.getId());
+        takeOrderSupportService(orderSupport);
+        orderSupportService.updateSupportToPrepare(orderSupport.getId());
 
         // then
-        Assertions.assertEquals("PREPARE", entity.getStatus().name());
+        Assertions.assertEquals("PREPARE", orderSupport.getStatus().name());
     }
 
     @Test
@@ -144,11 +136,11 @@ class OrderSupportServiceTest {
         given(orderSupportRepository.findById(any())).willReturn(Optional.of(orderSupport));
 
         // when
-        OrderSupport entity = takeOrderSupportService(orderSupport);
+        takeOrderSupportService(orderSupport);
         orderSupportService.answered(1L, answerRequest.content());
 
         // then
-        Assertions.assertEquals("ANSWERED", entity.getStatus().name());
+        Assertions.assertEquals("ANSWERED", orderSupport.getStatus().name());
     }
 
     @Test
@@ -161,11 +153,11 @@ class OrderSupportServiceTest {
         given(orderSupportRepository.findById(any())).willReturn(Optional.of(orderSupport));
 
         // when
-        OrderSupport entity = takeOrderSupportService(orderSupport);
-        orderSupportService.deleteOrderSupport(entity.getId());
+        takeOrderSupportService(orderSupport);
+        orderSupportService.deleteOrderSupport(orderSupport.getId());
 
         // then
-        Assertions.assertEquals("DELETED", entity.getStatus().name());
+        Assertions.assertEquals("DELETED", orderSupport.getStatus().name());
     }
 
     @Test
@@ -181,11 +173,11 @@ class OrderSupportServiceTest {
         given(orderSupportRepository.findById(any())).willReturn(Optional.of(orderSupport));
 
         // when
-        OrderSupport entity = takeOrderSupportService(orderSupport);
-        orderSupportService.updateOrderSupport(entity.getId(), updateRequest.title(), updateRequest.content());
+        takeOrderSupportService(orderSupport);
+        orderSupportService.updateOrderSupport(orderSupport.getId(), updateRequest.title(), updateRequest.content());
 
         // then
-        Assertions.assertEquals("updatedTitle", entity.getTitle());
-        Assertions.assertEquals("updatedContent", entity.getContent());
+        Assertions.assertEquals("updatedTitle", orderSupport.getTitle());
+        Assertions.assertEquals("updatedContent", orderSupport.getContent());
     }
 }


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠?
-->
# 🔍 어떤 PR인가요?
- 1:1문의 생성 후 Response DTO를 반환해주도록 변경했습니다!
- 1:1 문의 API 명세가 맞춰져 있지 않던 부분을 저희 팀 API 명세로 변경하였습니다!
- OrderSupport의 메소드 순서를 변경해 주었습니다! (생성자 -> getter -> 사용자 정의)
- 1:1 문의 내용이 수정되면 updateAt도 같이 수정되도록 변경하였습니다!

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail : 중복된 이메일로 저장 실패 테스트 작성)
-->
# ✅ Test
- 1:1 문의 DTO 적용 한 테스트 코드로 수정
