### PR TITLE
[KM-241] 수정:Global Exception Handler에 인증 예외 추가

### DIFF
--- a/module-api/src/main/java/com/devcourse/kurlymurly/user/UserController.java
+++ b/module-api/src/main/java/com/devcourse/kurlymurly/user/UserController.java
@@ -60,7 +60,7 @@ public class UserController {
     @Tag(name = "user")
     @Operation(description = "로그인 API", responses = {
             @ApiResponse(responseCode = "200", description = "로그인에 성공한 경우"),
-            @ApiResponse(responseCode = "400", description = "잘못된 로그인 정보를 입력한 경우"),
+            @ApiResponse(responseCode = "422", description = "잘못된 로그인 정보를 입력한 경우"),
     })
     @PostMapping("/login")
     @ResponseStatus(OK)

--- a/module-core/src/main/java/com/devcourse/kurlymurly/global/exception/ErrorCode.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/global/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 public enum ErrorCode {
     // 400
@@ -37,8 +38,11 @@ public enum ErrorCode {
     // 409
     NOT_ORDER_HOST(CONFLICT, "해당 주문을 주문한 사용자가 아닙니다."),
     NOT_AUTHOR(CONFLICT, "작성자가 아닙니다."),
-    EXIST_SAME_ID(CONFLICT,"사용 불가능한 아이디 입니다."),
-    EXIST_SAME_EMAIL(CONFLICT,"사용 불가능한 이메일 입니다."),
+    EXIST_SAME_ID(CONFLICT, "사용 불가능한 아이디 입니다."),
+    EXIST_SAME_EMAIL(CONFLICT, "사용 불가능한 이메일 입니다."),
+
+    // 422
+    BAD_CREDENTIAL(UNPROCESSABLE_ENTITY, "아이디, 비밀번호를 확인해주세요."),
 
     // 500
     KURLY_SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 내부 문제입니다. 관리자에게 문의바랍니다."),

--- a/module-core/src/main/java/com/devcourse/kurlymurly/global/exception/GlobalExceptionHandler.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,6 +14,8 @@ import static com.devcourse.kurlymurly.global.exception.ErrorCode.CLIENT_INPUT_I
 import static com.devcourse.kurlymurly.global.exception.ErrorCode.KURLY_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -41,6 +44,16 @@ public class GlobalExceptionHandler {
             String requestURI = request.getRequestURI();
             log.info("ValidationFailed at {} : {}", requestURI, errorMessage);
             return new ErrorResponse(CLIENT_INPUT_INVALID.name(), errorMessage);
+    }
+
+    /**
+     * 인증 실패 예외를 잡아주는 핸들러
+     */
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(UNPROCESSABLE_ENTITY)
+    public ErrorResponse handleUnexpectedException(BadCredentialsException e) {
+        log.warn("BadCredentialException Occurs : {}", e.getMessage());
+        return ErrorResponse.from(ErrorCode.BAD_CREDENTIAL);
     }
 
     /**

--- a/module-core/src/main/java/com/devcourse/kurlymurly/global/jwt/JwtTokenProvider.java
+++ b/module-core/src/main/java/com/devcourse/kurlymurly/global/jwt/JwtTokenProvider.java
@@ -11,6 +11,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.xml.bind.DatatypeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,6 +29,7 @@ import java.util.stream.Collectors;
 
 @Component
 public class JwtTokenProvider {
+    private static final Logger log = LoggerFactory.getLogger(JwtTokenProvider.class);
     private static final long expiration = 30 * 60 * 1000L;
 
     private final Key key;
@@ -82,14 +85,16 @@ public class JwtTokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            throw new KurlyBaseException(ErrorCode.NOT_CORRECT_JWT_SIGN);
+            log.warn("JWT Exception Occurs : {}", ErrorCode.NOT_CORRECT_JWT_SIGN);
         } catch (ExpiredJwtException e) {
-            throw new KurlyBaseException(ErrorCode.EXPIRED_JWT_TOKEN);
+            log.warn("JWT Exception Occurs : {}", ErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
-            throw new KurlyBaseException(ErrorCode.NOT_SUPPORTED_JWT_TOKEN);
+            log.warn("JWT Exception Occurs : {}", ErrorCode.NOT_SUPPORTED_JWT_TOKEN);
         } catch (IllegalArgumentException e) {
-            throw new KurlyBaseException(ErrorCode.NOT_CORRECT_JWT);
+            log.warn("JWT Exception Occurs : {}", ErrorCode.NOT_CORRECT_JWT);
         }
+
+        return false;
     }
 
     private Claims parseClaims(String accessToken) {


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 기존에는 잘못된 아이디 , 비밀번호를 입력하면 500 에러가 나왔지만 직관적인 예외 처리를 위해 
BadCredential 예외를 잡아주도록 하였습니다.
- 추가로 JWT 예외 발생 시 예외를 던지던 로직을 로그만 출력하도록 변경하였습니다 !

# 😋 To Reviewer
- 마켓컬리와 동일하게 422 예외를 반환하도록 하였습니다.
- 예외 메세지는 해당 문구와 동일하게 처리하였습니다.
![image](https://github.com/prgrms-be-devcourse/BE-04-KurlyMurly/assets/102570281/547ec93b-d722-4054-81a1-ce170bb0b087)

- BadCredential 만을 처리하는 핸들러를 아예 새로 만들었는데 , 논의 후에 합치는 방향으로 해도 좋을 거 같습니당
