### PR TITLE
수정 : 로그인 인증 예외 핸들러 적용 및 JWT 예외 반환 로직 수정

### DIFF
--- a/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
+++ b/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import com.devcourse.kurlymurly.common.exception.KurlyBaseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -52,7 +51,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(AuthenticationException.class)
     @ResponseStatus(UNPROCESSABLE_ENTITY)
-    public ErrorResponse handleUnexpectedException(AuthenticationException e) {
+    public ErrorResponse handleLoginFailException(AuthenticationException e) {
         log.warn("LoginFailed : {}", e.getClass().getSimpleName());
         log.warn("ErrorMessage : {}", e.getMessage());
         return ErrorResponse.from(ErrorCode.BAD_CREDENTIAL);
@@ -63,7 +62,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(INTERNAL_SERVER_ERROR)
-    public ErrorResponse handleUnexpectedException(RuntimeException e) {
+    public ErrorResponse handleLoginFailException(RuntimeException e) {
         log.warn("UnexpectedException Occurs : {}", e.getMessage());
         return ErrorResponse.from(KURLY_SERVER_ERROR);
     }

--- a/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
+++ b/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -36,23 +37,25 @@ public class GlobalExceptionHandler {
 
     /**
      * Bean Validation 실패를 잡아주는 예외 핸들러
+     *
      * @Validated는 아직 미적용
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-        @ResponseStatus(BAD_REQUEST)
-        public ErrorResponse handleValidationFailException(MethodArgumentNotValidException e) {
-            String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-            log.info("ValidationFailed : {}", errorMessage);
-            return new ErrorResponse(CLIENT_INPUT_INVALID.name(), errorMessage);
+    @ResponseStatus(BAD_REQUEST)
+    public ErrorResponse handleValidationFailException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.info("ValidationFailed : {}", errorMessage);
+        return new ErrorResponse(CLIENT_INPUT_INVALID.name(), errorMessage);
     }
 
     /**
      * 인증 실패 예외를 잡아주는 핸들러
      */
-    @ExceptionHandler(BadCredentialsException.class)
+    @ExceptionHandler(AuthenticationException.class)
     @ResponseStatus(UNPROCESSABLE_ENTITY)
-    public ErrorResponse handleUnexpectedException(BadCredentialsException e) {
-        log.warn("BadCredentialException Occurs : {}", e.getMessage());
+    public ErrorResponse handleUnexpectedException(AuthenticationException e) {
+        log.warn("LoginFailed : {}", e.getClass().getSimpleName());
+        log.warn("ErrorMessage : {}", e.getMessage());
         return ErrorResponse.from(ErrorCode.BAD_CREDENTIAL);
     }
 
@@ -62,7 +65,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(INTERNAL_SERVER_ERROR)
     public ErrorResponse handleUnexpectedException(RuntimeException e) {
-        log.warn("UnexpectedException Occurs : {}", e.getMessage());
+        log.warn("UnexpectedException Occurs : {},{}", e.getMessage(), e.getClass());
         return ErrorResponse.from(KURLY_SERVER_ERROR);
     }
 }

--- a/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
+++ b/kurly-core/src/main/java/com/devcourse/kurlymurly/global/GlobalExceptionHandler.java
@@ -37,7 +37,6 @@ public class GlobalExceptionHandler {
 
     /**
      * Bean Validation 실패를 잡아주는 예외 핸들러
-     *
      * @Validated는 아직 미적용
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -65,7 +64,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(RuntimeException.class)
     @ResponseStatus(INTERNAL_SERVER_ERROR)
     public ErrorResponse handleUnexpectedException(RuntimeException e) {
-        log.warn("UnexpectedException Occurs : {},{}", e.getMessage(), e.getClass());
+        log.warn("UnexpectedException Occurs : {}", e.getMessage());
         return ErrorResponse.from(KURLY_SERVER_ERROR);
     }
 }

--- a/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtAuthenticationFilter.java
+++ b/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtAuthenticationFilter.java
@@ -38,7 +38,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         try {
-            tokenProvider.validateToken(token);
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtAuthenticationFilter.java
+++ b/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtAuthenticationFilter.java
@@ -1,21 +1,32 @@
 package com.devcourse.kurlymurly.auth.jwt;
 
+import com.devcourse.kurlymurly.common.exception.ErrorCode;
+import com.devcourse.kurlymurly.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.core.annotation.Order;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.devcourse.kurlymurly.common.exception.ErrorCode.EXPIRED_JWT_TOKEN;
+import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_CORRECT_JWT;
+import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_CORRECT_JWT_SIGN;
+import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_SUPPORTED_JWT_TOKEN;
+
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider tokenProvider;
-
     private static final String BEARER_PREFIX = "Bearer ";
 
     public JwtAuthenticationFilter(JwtProvider tokenProvider) {
@@ -26,12 +37,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
 
-        if (tokenProvider.isValidToken(token)) {
+        try {
+            tokenProvider.validateToken(token);
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
 
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            setErrorResponse(response, NOT_CORRECT_JWT_SIGN);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, EXPIRED_JWT_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            setErrorResponse(response, NOT_SUPPORTED_JWT_TOKEN);
+        } catch (IllegalArgumentException e) {
+            setErrorResponse(response, NOT_CORRECT_JWT);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.addHeader("Content-Type", "application/json; charset=UTF-8");
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.name(), errorCode.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtProvider.java
+++ b/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtProvider.java
@@ -74,16 +74,8 @@ public class JwtProvider {
         }
     }
 
-    public void validateToken(String token) {
-        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-    }
-
     private Claims parseClaims(String accessToken) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
     }
 }
 

--- a/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtProvider.java
+++ b/kurly-internal/kurly-auth/src/main/java/com/devcourse/kurlymurly/auth/jwt/JwtProvider.java
@@ -1,18 +1,13 @@
 package com.devcourse.kurlymurly.auth.jwt;
 
 import com.devcourse.kurlymurly.auth.CustomUserDetailService;
-import com.devcourse.kurlymurly.common.exception.ErrorCode;
 import com.devcourse.kurlymurly.common.exception.KurlyBaseException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.xml.bind.DatatypeConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,15 +22,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 
-import static com.devcourse.kurlymurly.common.exception.ErrorCode.EXPIRED_JWT_TOKEN;
 import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_AUTHORIZED_TOKEN;
-import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_CORRECT_JWT;
-import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_CORRECT_JWT_SIGN;
-import static com.devcourse.kurlymurly.common.exception.ErrorCode.NOT_SUPPORTED_JWT_TOKEN;
 
 @Component
 public class JwtProvider {
-    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
     private static final long EXPIRATION_TIME = 30 * 60 * 1000L;
     private static final String AUTHORITY = "authority";
 
@@ -84,21 +74,8 @@ public class JwtProvider {
         }
     }
 
-    public boolean isValidToken(String token) {
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.warn("JWT Exception Occurs : {}", NOT_CORRECT_JWT_SIGN);
-        } catch (ExpiredJwtException e) {
-            log.warn("JWT Exception Occurs : {}", EXPIRED_JWT_TOKEN);
-        } catch (UnsupportedJwtException e) {
-            log.warn("JWT Exception Occurs : {}", NOT_SUPPORTED_JWT_TOKEN);
-        } catch (IllegalArgumentException e) {
-            log.warn("JWT Exception Occurs : {}", NOT_CORRECT_JWT);
-        }
-
-        throw new KurlyBaseException(ErrorCode.CHECK_TOKEN_ERROR);
+    public void validateToken(String token) {
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
     }
 
     private Claims parseClaims(String accessToken) {

--- a/kurly-support/kurly-common-support/src/main/java/com/devcourse/kurlymurly/common/exception/ErrorCode.java
+++ b/kurly-support/kurly-common-support/src/main/java/com/devcourse/kurlymurly/common/exception/ErrorCode.java
@@ -24,9 +24,8 @@ public enum ErrorCode {
     NOT_CORRECT_JWT_SIGN(UNAUTHORIZED, "잘못된 JWT SIGN값입니다."),
     NOT_CORRECT_JWT(UNAUTHORIZED, "잘못된 JWT 토큰입니다."),
     EXPIRED_JWT_TOKEN(UNAUTHORIZED, "만료된 토큰입니다."),
-    NOT_SUPPORTED_JWT_TOKEN(UNAUTHORIZED, "지원하지 않는 토근입니다."),
+    NOT_SUPPORTED_JWT_TOKEN(UNAUTHORIZED, "지원하지 않는 토큰입니다."),
     NOT_AUTHORIZED_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다."),
-    CHECK_TOKEN_ERROR(BAD_REQUEST, "토큰 값을 확인해주세요."),
 
     // 404
     NOT_FOUND_REVIEW(NOT_FOUND, "존재하는 리뷰가 없습니다."),


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 로그인 실패 시 기존 500 예외를 반환했던 문제에 대해 예외 핸들러를 수정하여서 정상적으로 예외를 반환하도록 하였습니다.
- JWT 검증 실패 시에 500 예외를 반환했던 문제에 대해 예외 반환 로직을 수정하여서 정상적으로 예외를 반환하도록 하였습니다.

# 😋 To Reviewer
- JWT 예외 같은 경우 필터에서 예외가 발생되기 때문에 @RestControllerAdvice의 범위 밖이라는 것을 알게되었습니다.
- 따라서 예외 핸들러가 아닌 필터 내에서 직접 응답을 반환하도록 하였습니다 !
![image](https://github.com/prgrms-be-devcourse/BE-04-KurlyMurly/assets/102570281/76361c54-7853-42e7-b400-c512bfe7bc32)



